### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: meza/action-go-ci@d69ce50e27eb0bc391fcb33b5beeef51c611d8c0 # main
         id: go


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.