### PR TITLE
chore(ci): use meza ubuntu slim runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     steps:
       - uses: meza/action-go-ci@d69ce50e27eb0bc391fcb33b5beeef51c611d8c0 # main
         id: go


### PR DESCRIPTION
## Summary

Replace `runs-on: self-hosted` with `runs-on: meza-ubuntu-slim` in 1 GitHub Actions workflow file.

## Validation

- Verified 1 exact runner-label replacement.
- Verified no other staged lines changed.
- `git diff --check` passes.